### PR TITLE
fix for dependency issue

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -153,7 +153,7 @@ Library
     iteratee >= 0.3.1 && < 0.4,
     ListLike >= 1 && < 2,
     MonadCatchIO-transformers >= 0.2.1 && < 0.3,
-    monads-fd,
+    monads-fd < 0.1.0.3,
     old-locale,
     old-time,
     text >= 0.10 && <0.11,


### PR DESCRIPTION
If `monads-fd` is not yet installed a `cabal install snap-core` currently fails. This patch resolves that issue.
