### PR TITLE
Add preServeHook to DirectoryConfig

### DIFF
--- a/test/suite/Snap/Util/FileServe/Tests.hs
+++ b/test/suite/Snap/Util/FileServe/Tests.hs
@@ -224,7 +224,8 @@ testFsCfg = testCase "fileServe/Cfg" $ do
         indexFiles      = [],
         indexGenerator  = const pass,
         dynamicHandlers = Map.empty,
-        mimeTypes       = defaultMimeTypes
+        mimeTypes       = defaultMimeTypes,
+        preServeHook    = const $ return ()
         }
 
     -- Named file in the root directory
@@ -266,7 +267,8 @@ testFsCfg = testCase "fileServe/Cfg" $ do
         indexFiles      = ["index.txt", "altindex.html"],
         indexGenerator  = const pass,
         dynamicHandlers = Map.empty,
-        mimeTypes       = defaultMimeTypes
+        mimeTypes       = defaultMimeTypes,
+        preServeHook    = const $ return ()
         }
 
     -- Request for root directory with index
@@ -296,7 +298,8 @@ testFsCfg = testCase "fileServe/Cfg" $ do
         indexFiles      = ["index.txt", "altindex.html"],
         indexGenerator  = printName,
         dynamicHandlers = Map.empty,
-        mimeTypes       = defaultMimeTypes
+        mimeTypes       = defaultMimeTypes,
+        preServeHook    = const $ return ()
         }
 
     -- Request for root directory with index
@@ -318,7 +321,8 @@ testFsCfg = testCase "fileServe/Cfg" $ do
         indexFiles      = [],
         indexGenerator  = const pass,
         dynamicHandlers = Map.fromList [ (".txt", printName) ],
-        mimeTypes       = defaultMimeTypes
+        mimeTypes       = defaultMimeTypes,
+        preServeHook    = const $ return ()
         }
 
     -- Request for file with dynamic handler


### PR DESCRIPTION
This commit adds a `preServeHook` field to the `DirectoryConfig`. This allows a user to have custom callbacks for files, while not having to implement directory serving by himself.
