### PR TITLE
Added the mime-type for the favicon.

### DIFF
--- a/src/Snap/Util/FileServe.hs
+++ b/src/Snap/Util/FileServe.hs
@@ -169,6 +169,7 @@ defaultMimeTypes = Map.fromList [
   ( ".hs"      , "text/plain"                        ),
   ( ".htm"     , "text/html"                         ),
   ( ".html"    , "text/html"                         ),
+  ( ".ico"     , "image/x-icon"                      ),
   ( ".jar"     , "application/x-java-archive"        ),
   ( ".jpeg"    , "image/jpeg"                        ),
   ( ".jpg"     , "image/jpeg"                        ),


### PR DESCRIPTION
This is the mime-type Apache uses. Is it desirable to have the whole mime-type DB from Apache in the code?
