### PR TITLE
fix nonascii filenames handling in FileServe.hs

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -156,7 +156,8 @@ Library
     unix-compat >= 0.2 && <0.4,
     unordered-containers >= 0.1.4.3 && <0.3,
     vector >= 0.6 && <0.10,
-    zlib-enum >= 0.2.1 && <0.3
+    zlib-enum >= 0.2.1 && <0.3,
+    utf8-string
 
   extensions:
     BangPatterns,

--- a/src/Snap/Util/FileServe.hs
+++ b/src/Snap/Util/FileServe.hs
@@ -36,6 +36,7 @@ import           Data.Attoparsec.Char8
 import qualified Data.ByteString.Char8 as S
 import           Data.ByteString.Char8 (ByteString)
 import           Data.ByteString.Internal (c2w)
+import qualified Data.ByteString.UTF8  as SU
 import           Data.Int
 import           Data.List
 import           Data.HashMap.Strict (HashMap)
@@ -55,7 +56,6 @@ import           Snap.Internal.Debug
 import           Snap.Internal.Parsing
 import           Snap.Iteratee hiding (drop)
 
-
 ------------------------------------------------------------------------------
 -- | Gets a path from the 'Request' using 'rqPathInfo' and makes sure it is
 -- safe to use for opening files.  A path is safe if it is a relative path
@@ -65,8 +65,7 @@ getSafePath = do
     req <- getRequest
     let mp = urlDecode $ rqPathInfo req
 
-    p <- maybe pass (return . S.unpack) mp
-
+    p <- maybe pass (return . SU.toString) mp
     -- relative paths only!
     when (not $ isRelative p) pass
 


### PR DESCRIPTION
Actually just change Data.ByteString.Char8.unpack to Data.ByteString.UTF8.toString
in getSafePath.
