### PR TITLE
No Content-Length for 204 or 304.

### DIFF
--- a/src/Snap/Internal/Types.hs
+++ b/src/Snap/Internal/Types.hs
@@ -973,7 +973,7 @@ fixupResponse req rsp = {-# SCC "fixupResponse" #-} do
     handle304 :: Response -> Response
     handle304 r = setResponseBody (enumBuilder mempty) $
                   updateHeaders (H.delete "Transfer-Encoding") $
-                  setContentLength 0 r
+                  clearContentLength r
 {-# INLINE fixupResponse #-}
 
 


### PR DESCRIPTION
It's better that the field `Content-Length` is cleared when the status code is 204 or 304, according to RFC 2616 sec 4.4, sec 10.2.5 and sec 10.3.5.
