### PR TITLE
Conditional Typeable deriving for GHC versions.

### DIFF
--- a/src/Snap/Internal/Types.hs
+++ b/src/Snap/Internal/Types.hs
@@ -143,10 +143,15 @@ data SnapResult a = SnapValue a
                   | EarlyTermination Response
 
 ------------------------------------------------------------------------------
+#if MIN_VERSION_base(4,7,0)
+newtype Snap a = Snap {
+      unSnap :: StateT SnapState (Iteratee ByteString IO) (SnapResult a)
+    } deriving (Typeable)
+#else
 newtype Snap a = Snap {
       unSnap :: StateT SnapState (Iteratee ByteString IO) (SnapResult a)
     }
-
+#endif
 
 ------------------------------------------------------------------------------
 data SnapState = SnapState
@@ -273,8 +278,10 @@ snapTyCon = mkTyCon "Snap.Core.Snap"
 #endif
 {-# NOINLINE snapTyCon #-}
 
+#if !MIN_VERSION_base(4,7,0)
 instance Typeable1 Snap where
     typeOf1 _ = mkTyConApp snapTyCon []
+#endif
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
It looks like Data.Typeable no longer exports Typeable1 so I added some CPP conditions to make Snap.Internal.Types compile. My changes may be naive - please check! But snap-core now builds and installs for me on ghc7.7.2013.11.06.
