### PR TITLE
Fix expireCookie according to documentation

### DIFF
--- a/src/Snap/Internal/Types.hs
+++ b/src/Snap/Internal/Types.hs
@@ -1222,7 +1222,7 @@ expireCookie :: (MonadSnap m)
 expireCookie nm dm = do
   let old = UTCTime (ModifiedJulianDay 0) 0
   modifyResponse $ addResponseCookie
-                 $ Cookie nm "" (Just old) Nothing dm False False
+                 $ Cookie nm "" (Just old) dm Nothing False False
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The docs say 'domain', but the string was passed in the 'path' position to the constructor.
