### PR TITLE
Add '_' to url unreserved chars list

### DIFF
--- a/src/Snap/Internal/Parsing.hs
+++ b/src/Snap/Internal/Parsing.hs
@@ -379,7 +379,7 @@ urlEncodeBuilder = go mempty
 urlEncodeClean :: Char -> Bool
 urlEncodeClean = toTable f
   where
-    f c = any ($ c) [isAlphaNum, flip elem "$-.!*'(),"]
+    f c = any ($ c) [isAlphaNum, flip elem "$_-.!*'(),"]
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
According to rfc2396 underscore is not reserved
http://tools.ietf.org/html/rfc2396.html#section-2.3

Though technically escaping everything is correct, this produces "better looking" urls

Also [section 3.3](http://tools.ietf.org/html/rfc2396.html#section-3.3) has more characters which don't need to be escaped in path segment.
`application/x-www-form-urlencoded` is different beast though.
