### PR TITLE
Widen dependency on time

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -148,7 +148,7 @@ Library
     random                    >= 1       && < 2,
     regex-posix               >= 0.95    && < 1,
     text                      >= 0.11    && < 1.3,
-    time                      >= 1.0     && < 1.5,
+    time                      >= 1.0     && < 1.6,
     unix-compat               >= 0.2     && < 0.5,
     unordered-containers      >= 0.1.4.3 && < 0.3,
     vector                    >= 0.6     && < 0.11,


### PR DESCRIPTION
This allows us to continue to work with the new version of time. If you could please issue a point release with this fix, that would be helpful (snap-server also needs a bump).
