### PR TITLE
match dir ".", dir "/", dir "" as root dir

### DIFF
--- a/src/Snap/Internal/Core.hs
+++ b/src/Snap/Internal/Core.hs
@@ -767,7 +767,7 @@ dir :: MonadSnap m
     -> m a
 dir = pathWith f
   where
-    f dr pinfo = dr == x
+    f dr pinfo = dr == x || (dr == "" || dr == "/" || dr == ".")
       where
         (x,_) = S.break (=='/') pinfo
 {-# INLINE dir #-}


### PR DESCRIPTION
Make it possible to detect requests to things in the root directory and redirect them.
useful example:
dir "." (serveDirectory "static")

user@host:~$ curl localhost:8000/
will serve static/index.html

The difference to ifTop is that it will also match files and subdirectories inside of /