### PR TITLE
urlEncode values out of ASCII range

### DIFF
--- a/src/Snap/Internal/Parsing.hs
+++ b/src/Snap/Internal/Parsing.hs
@@ -383,8 +383,9 @@ urlEncodeBuilder = go mempty
 urlEncodeClean :: Char -> Bool
 urlEncodeClean = toTable f
   where
-    f c = any ($ c) [isAlphaNum, flip elem [ '$', '_', '-', '.', '!'
-                                           , '*' , '\'', '(', ')', ',' ]]
+    f c = any ($ c) [\c -> isAscii c && isAlphaNum c
+                    , flip elem [ '$', '_', '-', '.', '!'
+                                , '*' , '\'', '(', ')', ',' ]]
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
isAlphaNum alone is not sufficient here, for example `isAlphaNum '\209' == True`