### PR TITLE
snap-core.cabal: add missing file to tarball

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -55,6 +55,7 @@ extra-source-files:
   test/data/fileServe/foo.html,
   test/data/fileServe/foo.txt,
   test/data/fileServe/mydir1/index.txt,
+  test/data/fileServe/mydir2/dir/foo.txt,
   test/data/fileServe/mydir2/foo.txt,
   test/data/fileServe/mydir3/altindex.html,
   test/Snap/Core/Tests.hs,


### PR DESCRIPTION
Noticed a s a test failure when imported package:

  snap-core-1.0.0.0:./dist/build/testsuite/testsuite -t fileServe/cfgFancy
  Snap.Util.FileServe.Tests:
    fileServe/cfgFancy: [Failed]
  autogen-sub-dir

           Test Cases  Total
   Passed  0           0
   Failed  1           1
   Total   1           1

Signed-off-by: Sergei Trofimovich <siarheit@google.com>