### PR TITLE
[WIP] FileUploads improvement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 1.0.3.0
+### Added
+- Alternative file upload handling into Snap.Util.FileUploads
+
 ## 1.0.2.1
 ### Dependencies
 - Allow `io-streams` 1.4.

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -1,5 +1,5 @@
 name:           snap-core
-version:        1.0.2.1
+version:        1.0.3.0
 synopsis:       Snap: A Haskell Web Framework (core interfaces and types)
 
 description:

--- a/src/Snap/Internal/Util/FileUploads.hs
+++ b/src/Snap/Internal/Util/FileUploads.hs
@@ -249,7 +249,7 @@ handleFormUploads uploadPolicy filePolicy partHandler = do
     (params, !st) <- foldMultipart uploadPolicy go (UploadState 0 id)
     return (params, uploadedFiles st [])
   where
-    go partInfo stream st = do
+    go !partInfo stream !st = do
         when (numUploads >= maxFiles) throwTooManyFiles
 
         case partFileName partInfo of

--- a/src/Snap/Util/FileUploads.hs
+++ b/src/Snap/Util/FileUploads.hs
@@ -61,9 +61,13 @@
 -- @
 module Snap.Util.FileUploads
   ( -- * Functions
-    foldMultipart
+    handleFormUploads
+  , foldMultipart
   , PartFold
   , FormParam
+  , FormFile
+  , storeAsLazyByteString
+  , withTemporaryStore
     -- ** Backwards compatible API
   , handleFileUploads
   , handleMultipart
@@ -95,6 +99,14 @@ module Snap.Util.FileUploads
   , getUploadTimeout
   , setUploadTimeout
 
+    -- *** File upload policy
+  , FileUploadPolicy
+  , defaultFileUploadPolicy
+  , setMaximumFileSize
+  , setMaximumNumberOfFiles
+  , setSkipFilesWithoutNames
+  , setStoreFilesWithoutNames
+
     -- *** Per-file upload policy
   , PartUploadPolicy
   , disallow
@@ -110,4 +122,4 @@ module Snap.Util.FileUploads
   ) where
 
 
-import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, FormParam, PartDisposition (..), PartFold, PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, foldMultipart, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleMultipart, setMaximumFormInputSize, setMaximumNumberOfFormInputs, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setUploadTimeout)
+import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, FileUploadPolicy, FormFile, FormParam, PartDisposition (..), PartFold, PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultFileUploadPolicy, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, foldMultipart, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleFormUploads, handleMultipart, setMaximumFileSize, setMaximumFormInputSize, setMaximumNumberOfFiles, setMaximumNumberOfFormInputs, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setSkipFilesWithoutNames, setStoreFilesWithoutNames, setUploadTimeout, storeAsLazyByteString, withTemporaryStore)

--- a/src/Snap/Util/FileUploads.hs
+++ b/src/Snap/Util/FileUploads.hs
@@ -65,7 +65,7 @@ module Snap.Util.FileUploads
   , foldMultipart
   , PartFold
   , FormParam
-  , FormFile
+  , FormFile (..)
   , storeAsLazyByteString
   , withTemporaryStore
     -- ** Backwards compatible API
@@ -105,7 +105,7 @@ module Snap.Util.FileUploads
   , setMaximumFileSize
   , setMaximumNumberOfFiles
   , setSkipFilesWithoutNames
-  , setStoreFilesWithoutNames
+  , setMaximumSkippedFileSize
 
     -- *** Per-file upload policy
   , PartUploadPolicy
@@ -122,4 +122,4 @@ module Snap.Util.FileUploads
   ) where
 
 
-import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, FileUploadPolicy, FormFile, FormParam, PartDisposition (..), PartFold, PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultFileUploadPolicy, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, foldMultipart, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleFormUploads, handleMultipart, setMaximumFileSize, setMaximumFormInputSize, setMaximumNumberOfFiles, setMaximumNumberOfFormInputs, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setSkipFilesWithoutNames, setStoreFilesWithoutNames, setUploadTimeout, storeAsLazyByteString, withTemporaryStore)
+import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, FileUploadPolicy, FormFile (..), FormParam, PartDisposition (..), PartFold, PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultFileUploadPolicy, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, foldMultipart, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleFormUploads, handleMultipart, setMaximumFileSize, setMaximumFormInputSize, setMaximumNumberOfFiles, setMaximumNumberOfFormInputs, setMaximumSkippedFileSize, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setSkipFilesWithoutNames, setUploadTimeout, storeAsLazyByteString, withTemporaryStore)

--- a/src/Snap/Util/FileUploads.hs
+++ b/src/Snap/Util/FileUploads.hs
@@ -61,7 +61,11 @@
 -- @
 module Snap.Util.FileUploads
   ( -- * Functions
-    handleFileUploads
+    foldMultipart
+  , PartFold
+  , FormParam
+    -- ** Backwards compatible API
+  , handleFileUploads
   , handleMultipart
   , PartProcessor
 
@@ -106,4 +110,4 @@ module Snap.Util.FileUploads
   ) where
 
 
-import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, PartDisposition (..), PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleMultipart, setMaximumFormInputSize, setMaximumNumberOfFormInputs, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setUploadTimeout)
+import           Snap.Internal.Util.FileUploads (BadPartException (badPartExceptionReason), FileUploadException, FormParam, PartDisposition (..), PartFold, PartInfo (..), PartProcessor, PartUploadPolicy, PolicyViolationException (policyViolationExceptionReason), UploadPolicy, allowWithMaximumSize, defaultUploadPolicy, disallow, doProcessFormInputs, fileUploadExceptionReason, foldMultipart, getMaximumFormInputSize, getMaximumNumberOfFormInputs, getMinimumUploadRate, getMinimumUploadSeconds, getUploadTimeout, handleFileUploads, handleMultipart, setMaximumFormInputSize, setMaximumNumberOfFormInputs, setMinimumUploadRate, setMinimumUploadSeconds, setProcessFormInputs, setUploadTimeout)

--- a/test/Snap/Util/FileUploads/Tests.hs
+++ b/test/Snap/Util/FileUploads/Tests.hs
@@ -161,7 +161,7 @@ testFilePolicyViolation1 = testCase "fileUploads/filePolicyViolation1" $
 
     hndl = handleFormUploads defaultUploadPolicy
              (setMaximumFileSize 0 defaultFileUploadPolicy)
-             storeAsLazyByteString
+             (const storeAsLazyByteString)
 
 
 
@@ -176,7 +176,7 @@ testFilePolicyViolation2 = testCase "fileUploads/filePolicyViolation2" $
 
     hndl = handleFormUploads defaultUploadPolicy
              (setMaximumNumberOfFiles 0 defaultFileUploadPolicy)
-             storeAsLazyByteString
+             (const storeAsLazyByteString)
 
 
 ------------------------------------------------------------------------------
@@ -188,7 +188,7 @@ testEmptyNamePolicyViolation = testCase "fileUploads/emptyNamePolicyViolation" $
 
     hndl = handleFormUploads defaultUploadPolicy
              (setSkipFilesWithoutNames True defaultFileUploadPolicy)
-             storeAsLazyByteString
+             (const storeAsLazyByteString)
 
 
 ------------------------------------------------------------------------------
@@ -207,7 +207,7 @@ testEmptyNameStore = testCase "fileUploads/emptyNameStore" $
     hndl = do
       (inputs, files) <- handleFormUploads defaultUploadPolicy
                          (setSkipFilesWithoutNames False defaultFileUploadPolicy)
-                         storeAsLazyByteString
+                         (const storeAsLazyByteString)
       liftIO $ do
          assertEqual "got both files" 2 (length files)
          let [f1, f2] = files
@@ -231,7 +231,7 @@ testEmptyNameSkip = testCase "fileUploads/emptyNameSkip" $
                          (  setMaximumSkippedFileSize 4000
                           . setSkipFilesWithoutNames True
                           $ defaultFileUploadPolicy )
-                         storeAsLazyByteString
+                         (const storeAsLazyByteString)
       liftIO $ do
          assertEqual "files skipped" 0 (length files)
          assertEqual "inputs present" 2 (length inputs)
@@ -247,7 +247,7 @@ testTemporaryStore = testCase "fileUploads/temporaryStore" $
       (fn1, fn2) <- withTemporaryStore "tempdir1" "upload" $ \store -> do
           (inputs, files) <- handleFormUploads defaultUploadPolicy
                                                defaultFileUploadPolicy
-                                               store
+                                               (const store)
           liftIO $ do
              assertEqual "num files" 2 (length files)
              assertEqual "inputs present" 2 (length inputs)
@@ -280,7 +280,7 @@ testTemporaryStoreSafeMove = testCase "fileUploads/temporaryStoreSafeMove" $
       withTemporaryStore "tempdir1" "upload" $ \store -> do
           (_, files) <- handleFormUploads defaultUploadPolicy
                                                defaultFileUploadPolicy
-                                               store
+                                               (const store)
           liftIO $ do
              assertEqual "num files" 2 (length files)
              let [FormFile _ fn1, FormFile _ fn2] = files


### PR DESCRIPTION
This is a wip branch for review and bikeshedding. do not merge.
Implements ideas discussed in #235

I've implemented foldMultipart and handleMultiparts in terms of it.

```haskell
foldMultipart ::
       (MonadSnap m) =>
       UploadPolicy        -- ^ global upload policy
    -> PartFold a          -- ^ part processor
    -> a                   -- ^ seed accumulator
    -> m a
```

All tests seem to pass, but I have additional tests I want to add, though now it properly checks the number of uploaded form inputs I think at some point tests were passing even though there were no checks in place.