### PR TITLE
Add CORS support to snap-core

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 1.0.1.3
+### Added
+- Merged CORS functionality from snap-cors project into Snap.Util.CORS
+
 ## 1.0.1.1
 ### Fixes
 - Fixed a bug in token parsing in Snap.Util.Parsing

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -264,6 +264,13 @@ Test-suite testsuite
     test-framework-quickcheck2 >= 0.2.12.1 && <0.4,
     zlib                       >= 0.5      && <0.7
 
+  if flag(network-uri)
+    build-depends: network-uri >= 2.6 && < 2.7,
+                   network     >= 2.6 && < 2.7
+  else
+    build-depends: network-uri >= 2.5 && < 2.6,
+                   network     >= 2.3 && < 2.6
+
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -threaded
                -fno-warn-unused-do-bind
 

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -85,6 +85,11 @@ Flag debug
   Default: False
 
 
+Flag network-uri
+  Description: Get Network.URI from the network-uri package
+  Default: True
+
+
 Library
   Default-language:  Haskell2010
   hs-source-dirs: src
@@ -102,6 +107,7 @@ Library
 
   exposed-modules:
     Snap.Core,
+    Snap.CORS,
     Snap.Internal.Core,
     Snap.Internal.Debug,
     Snap.Internal.Http.Types,
@@ -134,6 +140,7 @@ Library
     filepath                  >= 1.1     && < 2.0,
     lifted-base               >= 0.1     && < 0.3,
     io-streams                >= 1.3     && < 1.4,
+    hashable                  >= 1.2.0.6 && < 1.3,
     monad-control             >= 1.0     && < 1.1,
     mtl                       >= 2.0     && < 2.3,
     random                    >= 1       && < 2,
@@ -169,6 +176,13 @@ Library
     ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind
   else
     ghc-options: -Wall -fwarn-tabs
+
+  if flag(network-uri)
+    build-depends: network-uri >= 2.6 && < 2.7,
+                   network     >= 2.6 && < 2.7
+  else
+    build-depends: network-uri >= 2.5 && < 2.6,
+                   network     >= 2.3 && < 2.6
 
 
 Test-suite testsuite

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -1,5 +1,5 @@
 name:           snap-core
-version:        1.0.1.2
+version:        1.0.1.3
 synopsis:       Snap: A Haskell Web Framework (core interfaces and types)
 
 description:
@@ -107,13 +107,13 @@ Library
 
   exposed-modules:
     Snap.Core,
-    Snap.CORS,
     Snap.Internal.Core,
     Snap.Internal.Debug,
     Snap.Internal.Http.Types,
     Snap.Internal.Parsing,
     Snap.Test,
     Snap.Types.Headers,
+    Snap.Util.CORS,
     Snap.Util.FileServe,
     Snap.Util.FileUploads,
     Snap.Util.GZip,

--- a/src/Snap/CORS.hs
+++ b/src/Snap/CORS.hs
@@ -1,0 +1,280 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Add <http://www.w3.org/TR/cors/ CORS> (cross-origin resource sharing)
+-- headers to a Snap application. CORS headers can be added either conditionally
+-- or unconditionally to the entire site, or you can apply CORS headers to a
+-- single route.
+--
+-- To use in a snaplet, simply use 'wrapSite':
+--
+-- @
+-- wrapSite $ applyCORS defaultOptions
+-- @
+module Snap.CORS
+  ( -- * Applying CORS to a specific response
+    applyCORS
+
+    -- * Option Specification
+  , CORSOptions(..)
+  , defaultOptions
+
+    -- ** Origin lists
+  , OriginList(..)
+  , OriginSet, mkOriginSet, origins
+
+    -- * Internals
+  , HashableURI(..), HashableMethod (..)
+  ) where
+
+import Control.Applicative
+import Control.Monad (join, when)
+import Data.CaseInsensitive (CI)
+import Data.Hashable (Hashable(..))
+import Data.Maybe (fromMaybe)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Network.URI (URI (..), URIAuth (..),  parseURI)
+
+import qualified Data.Attoparsec.Combinator as Attoparsec
+import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.CaseInsensitive as CI
+import qualified Data.HashSet as HashSet
+import qualified Data.Text as Text
+import qualified Snap.Core as Snap
+
+-- | A set of origins. RFC 6454 specifies that origins are a scheme, host and
+-- port, so the 'OriginSet' wrapper around a 'HashSet.HashSet' ensures that each
+-- 'URI' constists of nothing more than this.
+newtype OriginSet = OriginSet { origins :: HashSet.HashSet HashableURI }
+
+-- | Used to specify the contents of the @Access-Control-Allow-Origin@ header.
+data OriginList
+  = Everywhere
+  -- ^ Allow any origin to access this resource. Corresponds to
+  -- @Access-Control-Allow-Origin: *@
+  | Nowhere
+  -- ^ Do not allow cross-origin requests
+  | Origins OriginSet
+  -- ^ Allow cross-origin requests from these origins.
+
+-- | Specify the options to use when building CORS headers for a response. Most
+-- of these options are 'Snap.Handler' actions to allow you to conditionally
+-- determine the setting of each header.
+data CORSOptions m = CORSOptions
+  { corsAllowOrigin :: m OriginList
+  -- ^ Which origins are allowed to make cross-origin requests.
+
+  , corsAllowCredentials :: m Bool
+  -- ^ Whether or not to allow exposing the response when the omit credentials
+  -- flag is unset.
+
+  , corsExposeHeaders :: m (HashSet.HashSet (CI Char8.ByteString))
+  -- ^ A list of headers that are exposed to clients. This allows clients to
+  -- read the values of these headers, if the response includes them.
+
+  , corsAllowedMethods :: m (HashSet.HashSet HashableMethod)
+  -- ^ A list of request methods that are allowed.
+
+  , corsAllowedHeaders :: HashSet.HashSet String -> m (HashSet.HashSet String)
+  -- ^ An action to determine which of the request headers are allowed.
+  -- This action is supplied the parsed contents of
+  -- @Access-Control-Request-Headers@.
+  }
+
+-- | Liberal default options. Specifies that:
+--
+-- * All origins may make cross-origin requests
+-- * @allow-credentials@ is true.
+-- * No extra headers beyond simple headers are exposed.
+-- * @GET@, @POST@, @PUT@, @DELETE@ and @HEAD@ are all allowed.
+-- * All request headers are allowed.
+--
+-- All options are determined unconditionally.
+defaultOptions :: Monad m => CORSOptions m
+defaultOptions = CORSOptions
+  { corsAllowOrigin = return Everywhere
+  , corsAllowCredentials = return True
+  , corsExposeHeaders = return HashSet.empty
+  , corsAllowedMethods =
+      return $ HashSet.fromList $ map HashableMethod
+        [ Snap.GET, Snap.POST, Snap.PUT, Snap.DELETE, Snap.HEAD ]
+  , corsAllowedHeaders = return
+  }
+
+
+-- | Apply CORS headers to a specific request. This is useful if you only have
+-- a single action that needs CORS headers, and you don't want to pay for
+-- conditional checks on every request.
+--
+-- You should note that 'applyCORS' needs to be used before you add any
+-- 'Snap.method' combinators. For example, the following won't do what you want:
+--
+-- > method POST $ applyCORS defaultOptions $ myHandler
+--
+-- This fails to work as CORS requires an @OPTIONS@ request in the preflighting
+-- stage, but this would get filtered out. Instead, use
+--
+-- > applyCORS defaultOptions $ method POST $ myHandler
+applyCORS :: Snap.MonadSnap m => CORSOptions m -> m () -> m ()
+applyCORS options m =
+  (join . fmap decodeOrigin <$> getHeader "Origin") >>= maybe m corsRequestFrom
+
+ where
+
+  corsRequestFrom origin = do
+    originList <- corsAllowOrigin options
+    if origin `inOriginList` originList
+       then Snap.method Snap.OPTIONS (preflightRequestFrom origin)
+              <|> handleRequestFrom origin
+       else m
+
+  preflightRequestFrom origin = do
+    maybeMethod <- fmap (parseMethod . Char8.unpack) <$>
+                     getHeader "Access-Control-Request-Method"
+
+    case maybeMethod of
+      Nothing -> m
+
+      Just method -> do
+        allowedMethods <- corsAllowedMethods options
+
+        if method `HashSet.member` allowedMethods
+          then do
+            maybeHeaders <-
+              fromMaybe (Just HashSet.empty) . fmap splitHeaders
+                <$> getHeader "Access-Control-Request-Headers"
+
+            case maybeHeaders of
+              Nothing -> m
+              Just headers -> do
+                allowedHeaders <- corsAllowedHeaders options headers
+
+                if not $ HashSet.null $ headers `HashSet.difference` allowedHeaders
+                   then m
+                   else do
+                     addAccessControlAllowOrigin origin
+                     addAccessControlAllowCredentials
+
+                     commaSepHeader
+                       "Access-Control-Allow-Headers"
+                       Char8.pack (HashSet.toList allowedHeaders)
+
+                     commaSepHeader
+                       "Access-Control-Allow-Methods"
+                       (Char8.pack . show) (HashSet.toList allowedMethods)
+
+          else m
+
+  handleRequestFrom origin = do
+    addAccessControlAllowOrigin origin
+    addAccessControlAllowCredentials
+
+    exposeHeaders <- corsExposeHeaders options
+    when (not $ HashSet.null exposeHeaders) $
+      commaSepHeader
+        "Access-Control-Expose-Headers"
+        CI.original (HashSet.toList exposeHeaders)
+
+    m
+
+  addAccessControlAllowOrigin origin =
+    addHeader "Access-Control-Allow-Origin"
+              (encodeUtf8 $ Text.pack $ show origin)
+
+  addAccessControlAllowCredentials = do
+    allowCredentials <- corsAllowCredentials options
+    when (allowCredentials) $
+      addHeader "Access-Control-Allow-Credentials" "true"
+
+  decodeOrigin = fmap simplifyURI . parseURI . Text.unpack . decodeUtf8
+
+  addHeader k v = Snap.modifyResponse (Snap.addHeader k v)
+
+  commaSepHeader k f vs =
+    case vs of
+      [] -> return ()
+      _  -> addHeader k $ Char8.intercalate ", " (map f vs)
+
+  getHeader = Snap.getsRequest . Snap.getHeader
+
+  splitHeaders =
+    let spaces = Attoparsec.many' Attoparsec.space
+        headerC = Attoparsec.satisfy (not . (`elem`( " ," :: String)))
+        headerName = Attoparsec.many' headerC
+        header = spaces *> headerName <* spaces
+        parser = HashSet.fromList <$> header `Attoparsec.sepBy` (Attoparsec.char ',')
+    in either (const Nothing) Just . Attoparsec.parseOnly parser
+
+mkOriginSet :: [URI] -> OriginSet
+mkOriginSet = OriginSet . HashSet.fromList . map (HashableURI . simplifyURI)
+
+simplifyURI :: URI -> URI
+simplifyURI uri = uri { uriAuthority = fmap simplifyURIAuth (uriAuthority uri)
+                       , uriPath = ""
+                       , uriQuery = ""
+                       , uriFragment = ""
+                       }
+ where simplifyURIAuth auth = auth { uriUserInfo = "" }
+
+--------------------------------------------------------------------------------
+parseMethod :: String -> HashableMethod
+parseMethod "GET"     = HashableMethod Snap.GET
+parseMethod "POST"    = HashableMethod Snap.POST
+parseMethod "HEAD"    = HashableMethod Snap.HEAD
+parseMethod "PUT"     = HashableMethod Snap.PUT
+parseMethod "DELETE"  = HashableMethod Snap.DELETE
+parseMethod "TRACE"   = HashableMethod Snap.TRACE
+parseMethod "OPTIONS" = HashableMethod Snap.OPTIONS
+parseMethod "CONNECT" = HashableMethod Snap.CONNECT
+parseMethod "PATCH"   = HashableMethod Snap.PATCH
+parseMethod s         = HashableMethod $ Snap.Method (Char8.pack s)
+
+--------------------------------------------------------------------------------
+-- | A @newtype@ over 'URI' with a 'Hashable' instance.
+newtype HashableURI = HashableURI URI
+  deriving (Eq)
+
+instance Show HashableURI where
+  show (HashableURI u) = show u
+
+instance Hashable HashableURI where
+  hashWithSalt s (HashableURI (URI scheme authority path query fragment)) =
+    s `hashWithSalt`
+    scheme `hashWithSalt`
+    fmap hashAuthority authority `hashWithSalt`
+    path `hashWithSalt`
+    query `hashWithSalt`
+    fragment
+
+   where
+    hashAuthority (URIAuth userInfo regName port) =
+          s `hashWithSalt`
+          userInfo `hashWithSalt`
+          regName `hashWithSalt`
+          port
+
+inOriginList :: URI -> OriginList -> Bool
+_ `inOriginList` Nowhere = False
+_ `inOriginList` Everywhere = True
+origin `inOriginList` (Origins (OriginSet xs)) =
+  HashableURI origin `HashSet.member` xs
+
+
+--------------------------------------------------------------------------------
+newtype HashableMethod = HashableMethod Snap.Method
+  deriving (Eq)
+
+instance Hashable HashableMethod where
+  hashWithSalt s (HashableMethod Snap.GET)        = s `hashWithSalt` (0 :: Int)
+  hashWithSalt s (HashableMethod Snap.HEAD)       = s `hashWithSalt` (1 :: Int)
+  hashWithSalt s (HashableMethod Snap.POST)       = s `hashWithSalt` (2 :: Int)
+  hashWithSalt s (HashableMethod Snap.PUT)        = s `hashWithSalt` (3 :: Int)
+  hashWithSalt s (HashableMethod Snap.DELETE)     = s `hashWithSalt` (4 :: Int)
+  hashWithSalt s (HashableMethod Snap.TRACE)      = s `hashWithSalt` (5 :: Int)
+  hashWithSalt s (HashableMethod Snap.OPTIONS)    = s `hashWithSalt` (6 :: Int)
+  hashWithSalt s (HashableMethod Snap.CONNECT)    = s `hashWithSalt` (7 :: Int)
+  hashWithSalt s (HashableMethod Snap.PATCH)      = s `hashWithSalt` (8 :: Int)
+  hashWithSalt s (HashableMethod (Snap.Method m)) =
+    s `hashWithSalt` (9 :: Int) `hashWithSalt` m
+
+instance Show HashableMethod where
+  show (HashableMethod m) = show m

--- a/src/Snap/Internal/Parsing.hs
+++ b/src/Snap/Internal/Parsing.hs
@@ -9,7 +9,7 @@ module Snap.Internal.Parsing where
 import           Control.Applicative              (Alternative ((<|>)), Applicative (pure, (*>), (<*)), liftA2, (<$>))
 import           Control.Arrow                    (first, second)
 import           Control.Monad                    (Monad (return), MonadPlus (mzero), liftM, when)
-import           Data.Attoparsec.ByteString.Char8 (IResult (Done, Fail, Partial), Parser, Result, anyChar, char, choice, decimal, endOfInput, feed, inClass, isDigit, isSpace, letter_ascii, many', match, option, parse, satisfy, skipSpace, skipWhile, string, take, takeTill, takeWhile)
+import           Data.Attoparsec.ByteString.Char8 (IResult (Done, Fail, Partial), Parser, Result, anyChar, char, choice, decimal, endOfInput, feed, inClass, isDigit, isSpace, letter_ascii, many', match, option, parse, satisfy, skipSpace, skipWhile, string, take, takeTill, takeWhile, sepBy')
 import qualified Data.Attoparsec.ByteString.Char8 as AP
 import           Data.Bits                        (Bits (unsafeShiftL, (.&.), (.|.)))
 import           Data.ByteString.Builder          (Builder, byteString, char8, toLazyByteString, word8)
@@ -269,6 +269,14 @@ isToken = toTable f
                                    , ':', '\\', '\"', '/', '[', ']'
                                    , '?', '=', '{', '}' ]
                  ]
+
+
+------------------------------------------------------------------------------
+{-# INLINE pTokens #-}
+-- | Used for "#field-name", and field-name = token, so "#token":
+-- comma-separated tokens/field-names, like a header field list.
+pTokens :: Parser [ByteString]
+pTokens = (skipSpace *> pToken <* skipSpace) `sepBy'` char ','
 
 
                               ------------------

--- a/src/Snap/Util/CORS.hs
+++ b/src/Snap/Util/CORS.hs
@@ -9,7 +9,7 @@
 -- @
 -- wrapSite $ applyCORS defaultOptions
 -- @
-module Snap.CORS
+module Snap.Util.CORS
   ( -- * Applying CORS to a specific response
     applyCORS
 
@@ -33,7 +33,6 @@ import Data.Maybe (fromMaybe)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Network.URI (URI (..), URIAuth (..),  parseURI)
 
-import qualified Data.Attoparsec.Combinator as Attoparsec
 import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
 import qualified Data.ByteString.Char8 as S
 import qualified Data.CaseInsensitive as CI

--- a/test/Snap/Internal/Parsing/Tests.hs
+++ b/test/Snap/Internal/Parsing/Tests.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString.Char8            as S (concat)
 import qualified Data.Map                         as Map (fromList)
 import           Data.Word                        (Word8)
 import           Snap.Internal.Http.Types         (Cookie (Cookie, cookieDomain, cookieExpires, cookieHttpOnly, cookieName, cookiePath, cookieSecure, cookieValue))
-import           Snap.Internal.Parsing            (crlf, finish, fullyParse, fullyParse', pAvPairs, pHeaders, pQuotedString, parseCookie, parseToCompletion, parseUrlEncoded, unsafeFromHex, unsafeFromNat)
+import           Snap.Internal.Parsing            (crlf, finish, fullyParse, fullyParse', pAvPairs, pHeaders, pQuotedString, parseCookie, parseToCompletion, parseUrlEncoded, unsafeFromHex, unsafeFromNat, pTokens)
 import           Snap.Test.Common                 (expectExceptionH)
 import           System.Random                    (Random (random, randomR))
 import           Test.Framework                   (Test)
@@ -28,6 +28,7 @@ tests = [ testAvPairs
         , testUnsafeFromInt
         , testUrlEncoded
         , testFailParse
+        , testTokens
         ]
 
 
@@ -154,3 +155,12 @@ testFailParse = testCase "parsing/failParse" $ do
 
     return $! length a `seq` length b `seq` length c `seq` length d `seq` e
                        `seq` length g `seq` z `seq` ()
+
+
+------------------------------------------------------------------------------
+testTokens :: Test
+testTokens = testCase "parsing/tokens" $ do
+  assertEqual "without whitespace" (Right ["Foo","Bar"]) $
+    fullyParse "Foo,Bar" pTokens
+  assertEqual "with whitespace" (Right ["Foo","Bar"]) $
+    fullyParse " Foo  ,Bar " pTokens

--- a/test/Snap/Util/CORS/Tests.hs
+++ b/test/Snap/Util/CORS/Tests.hs
@@ -10,7 +10,7 @@ import           Data.CaseInsensitive           (CI (..))
 import qualified Data.HashSet                   as HashSet
 import           Snap.Core                      (Method (..), getHeader, Response(..))
 import           Snap.Test                      (RequestBuilder, runHandler, setHeader, setRequestType, RequestType(..), setRequestPath)
-import           Snap.CORS                      (applyCORS,CORSOptions(..),defaultOptions,HashableMethod(..))
+import           Snap.Util.CORS                 (applyCORS,CORSOptions(..),defaultOptions,HashableMethod(..))
 import           Test.Framework                 (Test)
 import           Test.Framework.Providers.HUnit (testCase)
 import           Test.HUnit                     (assertEqual,Assertion)

--- a/test/Snap/Util/CORS/Tests.hs
+++ b/test/Snap/Util/CORS/Tests.hs
@@ -1,0 +1,109 @@
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Snap.Util.CORS.Tests (tests) where
+
+------------------------------------------------------------------------------
+import           Data.ByteString.Char8          (ByteString)
+import           Data.CaseInsensitive           (CI (..))
+import qualified Data.HashSet                   as HashSet
+import           Snap.Core                      (Method (..), getHeader, Response(..))
+import           Snap.Test                      (RequestBuilder, runHandler, setHeader, setRequestType, RequestType(..), setRequestPath)
+import           Snap.CORS                      (applyCORS,CORSOptions(..),defaultOptions,HashableMethod(..))
+import           Test.Framework                 (Test)
+import           Test.Framework.Providers.HUnit (testCase)
+import           Test.HUnit                     (assertEqual,Assertion)
+------------------------------------------------------------------------------
+
+
+------------------------------------------------------------------------------
+tests :: [Test]
+tests = [ testCORSSimple
+        , testCORSOptions
+        ]
+
+
+                                ---------------
+                                -- Constants --
+                                ---------------
+
+------------------------------------------------------------------------------
+origin :: ByteString
+origin = "http://origin.org"
+
+
+
+                                  -----------
+                                  -- Tests --
+                                  -----------
+
+------------------------------------------------------------------------------
+testCORSSimple :: Test
+testCORSSimple = testCase "CORS/simple" $ do
+    let testDefault meth = do
+          r <- runHandler (mkMethReq meth) $
+               applyCORS defaultOptions $ return ()
+          checkAllowOrigin (Just origin) r
+          checkAllowCredentials (Just "true") r
+          checkExposeHeaders Nothing r
+    mapM_ testDefault [GET,POST,PUT,DELETE,HEAD]
+
+------------------------------------------------------------------------------
+testCORSOptions :: Test
+testCORSOptions = testCase "CORS/options" $ do
+  let opts = applyCORS defaultOptions { corsAllowedMethods =
+               return $ HashSet.singleton $ HashableMethod GET  }
+  r <- runHandler (mkMethReq OPTIONS
+                   >> setRequestMethod "GET"
+                   >> setRequestHeaders "X-STUFF, Content-Type") $
+       opts $ return ()
+  checkAllowOrigin (Just origin) r
+  checkAllowCredentials (Just "true") r
+  checkAllowHeaders (Just "X-STUFF, Content-Type") r
+  checkAllowMethods (Just "GET") r
+  ---------------------------------------------------------
+  s <- runHandler (mkMethReq OPTIONS
+                   >> setRequestMethod "POST"
+                   >> setRequestHeaders "X-STUFF, Content-Type") $
+       opts $ return ()
+  checkAllowOrigin Nothing s
+  checkAllowCredentials Nothing s
+  checkAllowHeaders Nothing s
+  checkAllowMethods Nothing s
+
+
+                                ---------------
+                                -- Functions --
+                                ---------------
+
+------------------------------------------------------------------------------
+mkMethReq :: Method -> RequestBuilder IO ()
+mkMethReq meth = do
+  setRequestType $ RequestWithRawBody meth ""
+  setRequestPath "/"
+  setHeader "Origin" origin
+
+checkHeader :: CI ByteString -> Maybe ByteString -> Response -> Assertion
+checkHeader h v r = assertEqual ("Header " ++ show h) v (getHeader h r)
+
+checkAllowOrigin :: Maybe ByteString -> Response -> Assertion
+checkAllowOrigin = checkHeader "Access-Control-Allow-Origin"
+
+checkAllowCredentials :: Maybe ByteString -> Response -> Assertion
+checkAllowCredentials = checkHeader "Access-Control-Allow-Credentials"
+
+checkExposeHeaders :: Maybe ByteString -> Response -> Assertion
+checkExposeHeaders = checkHeader "Access-Control-Expose-Headers"
+
+checkAllowHeaders :: Maybe ByteString -> Response -> Assertion
+checkAllowHeaders = checkHeader "Access-Control-Allow-Headers"
+
+checkAllowMethods :: Maybe ByteString -> Response -> Assertion
+checkAllowMethods = checkHeader "Access-Control-Allow-Methods"
+
+setRequestMethod :: ByteString -> RequestBuilder IO ()
+setRequestMethod = setHeader "Access-Control-Request-Method"
+
+setRequestHeaders :: ByteString -> RequestBuilder IO ()
+setRequestHeaders = setHeader "Access-Control-Request-Headers"

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -13,6 +13,7 @@ import qualified Snap.Util.FileServe.Tests
 import qualified Snap.Util.FileUploads.Tests
 import qualified Snap.Util.GZip.Tests
 import qualified Snap.Util.Proxy.Tests
+import qualified Snap.Util.CORS.Tests
 
 
 ------------------------------------------------------------------------------
@@ -37,6 +38,8 @@ main = defaultMain tests
                         Snap.Util.GZip.Tests.tests
             , testGroup "Snap.Util.Proxy.Tests"
                         Snap.Util.Proxy.Tests.tests
+            , testGroup "Snap.Util.CORS.Tests"
+                        Snap.Util.CORS.Tests.tests
             , testGroup "Snap.Test.Tests"
                         Snap.Test.Tests.tests
             ]


### PR DESCRIPTION
See comment for https://github.com/snapframework/snap-server/pull/97 , moved to snap-core per @gregorycollins request. 

Module name back to Snap.CORS, which has the benefit of being the same as the `snap-cors` module. However if this should be somewhere else (Internal + core import, etc) let me know. 