### PR TITLE
Fix parsing of non us-ascii field values in multipart/form-data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 1.0.3.0
+### Fixes
+- Fixed parsing of field values in multipart/form-data headers with encodings
+  other than US-ASCII
+
 ## 1.0.2.0
 ### Added
 - Merged CORS functionality from snap-cors project into Snap.Util.CORS

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -1,5 +1,5 @@
 name:           snap-core
-version:        1.0.2.0
+version:        1.0.3.0
 synopsis:       Snap: A Haskell Web Framework (core interfaces and types)
 
 description:

--- a/src/Snap/Internal/Util/FileUploads.hs
+++ b/src/Snap/Internal/Util/FileUploads.hs
@@ -68,7 +68,7 @@ import qualified Data.Text.Encoding               as TE (decodeUtf8)
 import           Data.Typeable                    (Typeable, cast)
 import           Prelude                          (Bool (..), Double, Either (..), Eq (..), FilePath, IO, Ord (..), Show (..), String, const, either, flip, fst, id, max, not, otherwise, snd, ($), ($!), (.), (^), (||))
 import           Snap.Core                        (HasHeaders (headers), Headers, MonadSnap, Request (rqParams, rqPostParams), getHeader, getRequest, getTimeoutModifier, putRequest, runRequestBody)
-import           Snap.Internal.Parsing            (crlf, fullyParse, pContentTypeWithParameters, pHeaders, pValueWithParameters)
+import           Snap.Internal.Parsing            (crlf, fullyParse, pContentTypeWithParameters, pHeaders, pValueWithParameters')
 import qualified Snap.Types.Headers               as H (fromList)
 import           System.Directory                 (removeFile)
 import           System.FilePath                  ((</>))
@@ -696,7 +696,7 @@ getFieldHeaderInfo hdrs = (fieldName, fileName, disposition)
     contentDispositionValue = fromMaybe "unknown" $
                               getHeader "content-disposition" hdrs
 
-    eDisposition = fullyParse contentDispositionValue pValueWithParameters
+    eDisposition = fullyParse contentDispositionValue $ pValueWithParameters' (const True)
 
     (!dispositionType, dispositionParameters) =
         either (const ("unknown", [])) id eDisposition

--- a/test/Snap/Internal/Parsing/Tests.hs
+++ b/test/Snap/Internal/Parsing/Tests.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString.Char8            as S (concat)
 import qualified Data.Map                         as Map (fromList)
 import           Data.Word                        (Word8)
 import           Snap.Internal.Http.Types         (Cookie (Cookie, cookieDomain, cookieExpires, cookieHttpOnly, cookieName, cookiePath, cookieSecure, cookieValue))
-import           Snap.Internal.Parsing            (crlf, finish, fullyParse, fullyParse', pAvPairs, pHeaders, pQuotedString, parseCookie, parseToCompletion, parseUrlEncoded, unsafeFromHex, unsafeFromNat, pTokens)
+import           Snap.Internal.Parsing            (crlf, finish, fullyParse, fullyParse', pAvPairs, pHeaders, pQuotedString, pQuotedString', parseCookie, parseToCompletion, parseUrlEncoded, unsafeFromHex, unsafeFromNat, pTokens)
 import           Snap.Test.Common                 (expectExceptionH)
 import           System.Random                    (Random (random, randomR))
 import           Test.Framework                   (Test)
@@ -24,6 +24,7 @@ tests = [ testAvPairs
         , testCookie
         , testHeaderParse
         , testQuotedString
+        , testQuotedString'
         , testUnsafeFromHex
         , testUnsafeFromInt
         , testUrlEncoded
@@ -95,6 +96,16 @@ testQuotedString = testCase "parsing/quoted-string" $ do
 
   where
     txt = "\"foo\\\"bar\\\"baz\""
+
+------------------------------------------------------------------------------
+testQuotedString' :: Test
+testQuotedString' = testCase "parsing/quoted-string-utf8" $ do
+    let e = fullyParse qdtext $ pQuotedString' (const True)
+    assertEqual "q-s" (Right txt) e
+
+  where
+    txt = "\xd1\x82\xd0\xb5\xd1\x81\xd1\x82" -- "тест" as UTF-8
+    qdtext = S.concat ["\"", txt, "\""]
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
`pQuotedString` will fail if the value contains any control characters. This causes valid, quoted UTF-8 parameters in multipart/form-data headers to be parsed as unquoted ie. double quotes are interpreted as part of the value so you get `"ąę"` insted of `ąę` in filenames etc. This is an attempted fix.

See https://github.com/snapframework/snap-core/issues/150 for discussion.