### PR TITLE
snap-core.cabal: add missing tests file to source tarball

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -206,6 +206,7 @@ Test-suite testsuite
     Snap.Internal.Parsing,
     Snap.Test,
     Snap.Types.Headers,
+    Snap.Util.CORS.Tests,
     Snap.Util.FileServe,
     Snap.Util.FileUploads,
     Snap.Util.GZip,


### PR DESCRIPTION
Otherwise 'cabal test' failed as:
  test/TestSuite.hs:16:1: error:
    Failed to load interface for ‘Snap.Util.CORS.Tests’
    Use -v to see a list of the files searched for.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>