### PR TITLE
Fix handling of X-Forwarded-For.

### DIFF
--- a/src/Snap/Util/Proxy.hs
+++ b/src/Snap/Util/Proxy.hs
@@ -22,10 +22,10 @@ module Snap.Util.Proxy
 
 ------------------------------------------------------------------------------
 import           Control.Applicative   (Alternative ((<|>)))
-import           Control.Arrow         (second)
-import qualified Data.ByteString.Char8 as S (break, breakEnd, drop, dropWhile, readInt, spanEnd)
+import           Control.Monad         (mfilter)
+import qualified Data.ByteString.Char8 as S (breakEnd, dropWhile, null, readInt, spanEnd)
 import           Data.Char             (isSpace)
-import           Data.Maybe            (fromJust)
+import           Data.Maybe            (fromMaybe)
 import           Snap.Core             (MonadSnap, Request (rqClientAddr, rqClientPort), getHeader, modifyRequest)
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative   ((<$>))
@@ -81,16 +81,13 @@ xForwardedFor req = req { rqClientAddr = ip
                         , rqClientPort = port
                         }
   where
-    proxyString  = getHeader "Forwarded-For"   req <|>
-                   getHeader "X-Forwarded-For" req <|>
-                   Just (rqClientAddr req)
+    extract = fst . S.spanEnd isSpace . S.dropWhile isSpace . snd . S.breakEnd (== ',')
 
-    proxyAddr    = trim . snd . S.breakEnd (== ',') . fromJust $ proxyString
+    ip      = fromMaybe (rqClientAddr req) $ mfilter (not . S.null) $ extract <$>
+              getHeader "Forwarded-For"   req  <|>
+              getHeader "X-Forwarded-For" req
 
-    trim         = fst . S.spanEnd isSpace . S.dropWhile isSpace
-
-    (ip,portStr) = second (S.drop 1) . S.break (== ':') $ proxyAddr
-
-    port         = fromJust (fst <$> S.readInt portStr <|>
-                             Just (rqClientPort req))
+    port    = maybe (rqClientPort req) fst $ S.readInt =<< extract <$>
+              getHeader "Forwarded-Port"   req  <|>
+              getHeader "X-Forwarded-Port" req
 {-# INLINE xForwardedFor #-}


### PR DESCRIPTION
The `X_Forwarded_For` proxy type isn't handled correctly:

1.  The code attempts to parse a port out of the `X-Forwarded-For` header.  But proxies don't send the port in this header (as far as I know).  When sent at all, `X-Forwarded-Port` is used.

2.  The parsing splits on a `:` to find the port.  This breaks IPv6 addresses, which are colon-separated.  So, it interprets the first hextet (such as `2600`) as the user IP, and tries to get a decimal port out of the second hextet, which of course is a bad result.

3.  It does parsing even if there is no forwarding header, that is, to the original `rqClientAddr`.  This is inefficient, and also means that IPv6 addresses break even when the request is not forwarded.

This PR fixes these issues, and supports `X-Forwarded-Port`.  I also add a check that `X-Forwarded-For` is not empty.