### PR TITLE
Allow network-2.8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/templates/out
 cabal.sandbox.config
 cabal.project.local
 dist-newstyle
+.ghc.environment.*

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -185,10 +185,10 @@ Library
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6 && < 2.7,
-                   network     >= 2.6 && < 2.8
+                   network     >= 2.6 && < 2.9
   else
-    build-depends: network-uri >= 2.5 && < 2.7,
-                   network     >= 2.3 && < 2.8
+    build-depends: network-uri >= 2.5 && < 2.6,
+                   network     >= 2.3 && < 2.6
 
 
 Test-suite testsuite


### PR DESCRIPTION
Also fix the `network-uri` selection logic. I tested that the package builds against both `network-2.8` and `network-2.5`.

The only silently breaking changes in `network-2.8` concern the `Ord` instance for `PortNumber`, which doesn't seem to be used by `snap-core`.