### PR TITLE
Expose Snap.Internal.Util.FileServe

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -112,6 +112,7 @@ Library
     Snap.Internal.Debug,
     Snap.Internal.Http.Types,
     Snap.Internal.Parsing,
+    Snap.Internal.Util.FileServe,
     Snap.Test,
     Snap.Types.Headers,
     Snap.Util.CORS,
@@ -125,7 +126,6 @@ Library
     Snap.Internal.Routing,
     Snap.Internal.Test.RequestBuilder,
     Snap.Internal.Test.Assertions,
-    Snap.Internal.Util.FileServe,
     Snap.Internal.Util.FileUploads
 
 

--- a/src/Snap/Internal/Util/FileServe.hs
+++ b/src/Snap/Internal/Util/FileServe.hs
@@ -24,6 +24,7 @@ module Snap.Internal.Util.FileServe
   , serveFileAs
     -- * Internal functions
   , decodeFilePath
+  , checkRangeReq
   ) where
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
I also feel like the name of `checkRangeReq` is a little misleading, because it actually does _all_ of the work for range requests. Perhaps now would be a good time to change it?