### PR TITLE
Support random-1.2

### DIFF
--- a/src/Snap/Internal/Test/RequestBuilder.hs
+++ b/src/Snap/Internal/Test/RequestBuilder.hs
@@ -59,7 +59,7 @@ import qualified Snap.Internal.Http.Types   as H
 import qualified Snap.Types.Headers         as H
 import qualified System.IO.Streams          as Streams
 import           System.PosixCompat.Time    (epochTime)
-import           System.Random              (Random (randomIO))
+import           System.Random              (randomIO)
 import           Text.Printf                (printf)
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative        (Applicative)

--- a/test/Snap/Util/GZip/Tests.hs
+++ b/test/Snap/Util/GZip/Tests.hs
@@ -23,7 +23,7 @@ import qualified Snap.Test                            as Test
 import           Snap.Test.Common                     (coverTypeableInstance, expectException, expectExceptionH, liftQ)
 import           Snap.Util.GZip                       (BadAcceptEncodingException, noCompression, withCompression)
 import qualified System.IO.Streams                    as Streams
-import           System.Random                        (Random (randomIO))
+import           System.Random                        (randomIO)
 import           Test.Framework                       (Test)
 import           Test.Framework.Providers.HUnit       (testCase)
 import           Test.Framework.Providers.QuickCheck2 (testProperty)


### PR DESCRIPTION
Relevant bit of the changelog
(http://hackage.haskell.org/package/random-1.2.0/changelog):

> randomIO and randomRIO were extracted from the Random class into separate functions