### PR TITLE
Support random-1.2 in Gzip tests

### DIFF
--- a/test/Snap/Util/GZip/Tests.hs
+++ b/test/Snap/Util/GZip/Tests.hs
@@ -23,7 +23,7 @@ import qualified Snap.Test                            as Test
 import           Snap.Test.Common                     (coverTypeableInstance, expectException, expectExceptionH, liftQ)
 import           Snap.Util.GZip                       (BadAcceptEncodingException, noCompression, withCompression)
 import qualified System.IO.Streams                    as Streams
-import           System.Random                        (Random (randomIO))
+import           System.Random                        (randomIO)
 import           Test.Framework                       (Test)
 import           Test.Framework.Providers.HUnit       (testCase)
 import           Test.Framework.Providers.QuickCheck2 (testProperty)


### PR DESCRIPTION
It was present in #296 but #295 was merged instead which doesn't contain this.