### PR TITLE
Allow bytestring-0.11 + semigroups-0.19

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -133,7 +133,7 @@ Library
     HUnit                     >= 1.2     && < 2,
     attoparsec                >= 0.12    && < 0.14,
     base                      >= 4       && < 5,
-    bytestring                >= 0.9     && < 0.11,
+    bytestring                >= 0.9     && < 0.12,
     bytestring-builder        >= 0.10.4  && < 0.11,
     case-insensitive          >= 1.1     && < 1.3,
     containers                >= 0.3     && < 1.0,
@@ -184,7 +184,7 @@ Library
     if impl(ghc >= 8.0)
       ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
     else
-      build-depends: fail == 4.9.*, semigroups == 0.18.*
+      build-depends: fail == 4.9.*, semigroups >= 0.18 && < 0.20
 
   if flag(network-uri)
     -- Leaving network-uri-2.7.0.0 out for now because it is marked deprecated
@@ -291,7 +291,7 @@ Test-suite testsuite
     if impl(ghc >= 8.0)
       ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
     else
-      build-depends: fail == 4.9.*, semigroups == 0.18.*
+      build-depends: fail == 4.9.*, semigroups >= 0.18 && < 0.20
 
   other-extensions:
     BangPatterns,


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: True

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/zlib

allow-newer:
  regex-posix:bytestring,
  regex-base:bytestring
```