### PR TITLE
Ensure parseHttpTime returns 0 on invalid input

### DIFF
--- a/cbits/timefuncs.c
+++ b/cbits/timefuncs.c
@@ -10,9 +10,13 @@ void set_c_locale() {
 }
 
 
+// When given invalid input, returns 0.
 time_t c_parse_http_time(char* s) {
+    if (s == NULL) return 0;
     struct tm dest;
-    strptime(s, "%a, %d %b %Y %H:%M:%S GMT", &dest);
+    if (strptime(s, "%a, %d %b %Y %H:%M:%S GMT", &dest) == NULL) {
+        return 0;
+    }
     return timegm(&dest);
 }
 

--- a/src/Snap/Internal/Http/Types.hs
+++ b/src/Snap/Internal/Http/Types.hs
@@ -1235,6 +1235,8 @@ formatLogTime :: CTime -> IO ByteString
 ------------------------------------------------------------------------------
 -- | Converts an HTTP timestamp into a 'CTime'.
 --
+-- If the given time string is unparseable, this function will return 0.
+--
 -- Example:
 --
 -- @


### PR DESCRIPTION
### Background

My web server was getting requests with an empty `If-Modified-Since:` header from some kind of crawler, which [snap-server maps to an `empty` ByteString](https://github.com/snapframework/snap-server/blob/f9c6e00630a8a78705aceafa0ac046ae70e1310e/src/Snap/Internal/Http/Server/Parser.hs#L269). (Note that an `empty` ByteString is backed by a null pointer.) My server handled the relevant route using `serveFileAs`, which [passes that empty ByteString right on](https://github.com/snapframework/snap-core/blob/04295679ccf8316fcf4944f2eb65d1b5266587ef/src/Snap/Internal/Util/FileServe.hs#L601-L605) to `parseHttpTime`, which [calls `c_parse_http_time`](https://github.com/snapframework/snap-core/blob/04295679ccf8316fcf4944f2eb65d1b5266587ef/src/Snap/Internal/Http/Types.hs#L1307). Then [that C function](https://github.com/snapframework/snap-core/blob/04295679ccf8316fcf4944f2eb65d1b5266587ef/cbits/timefuncs.c#L13-L17) performs no checking on the input string, and gives a segmentation fault due to a null pointer dereference in this scenario. This brings down the web server.

### This PR

The null pointer dereference described above is fixed by a simple null pointer check. Additionally I added a check on the return value of `strptime`, just for completeness.