### PR TITLE
HEAD request test helpers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Jonas Kramer <jkramer@nex.scrapping.cc>
 Jurriën Stutterheim <j.stutterheim@me.com>
 Jasper Van der Jeugt <m@jaspervdj.be>
 Bryan O'Sullivan <bos@serpentine.com>
+Koz Ross <koz@mlabs.city>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 1.0.4.3
+
+- Add `head` helper for `Snap.Test`
+
 ## 1.0.4.0
 - Allow `network` 3.0.
 

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -1,5 +1,5 @@
 name:           snap-core
-version:        1.0.4.2
+version:        1.0.4.3
 synopsis:       Snap: A Haskell Web Framework (core interfaces and types)
 
 description:

--- a/src/Snap/Internal/Test/RequestBuilder.hs
+++ b/src/Snap/Internal/Test/RequestBuilder.hs
@@ -19,6 +19,7 @@ module Snap.Internal.Test.RequestBuilder
   , evalHandler
   , evalHandlerM
   , get
+  , head
   , postMultipart
   , postRaw
   , postUrlEncoded
@@ -52,6 +53,7 @@ import           Data.CaseInsensitive       (CI, original)
 import qualified Data.Map                   as Map
 import qualified Data.Vector                as V
 import           Data.Word                  (Word8)
+import           Prelude                    hiding (head)
 import           Snap.Core                  (Cookie (Cookie), Method (DELETE, GET, HEAD, POST, PUT), MonadSnap, Params, Request (rqContentLength, rqContextPath, rqCookies, rqHeaders, rqHostName, rqIsSecure, rqMethod, rqParams, rqPathInfo, rqPostParams, rqQueryParams, rqQueryString, rqURI, rqVersion), Response, Snap, deleteHeader, formatHttpTime, getHeader, parseUrlEncoded, printUrlEncoded, runSnap)
 import           Snap.Internal.Core         (evalSnap, fixupResponse)
 import           Snap.Internal.Http.Types   (Request (Request, rqBody), Response (rspBody, rspContentLength), rspBodyToEnum)
@@ -707,6 +709,30 @@ get uri params = do
     setQueryString params
     setRequestPath uri
 
+------------------------------------------------------------------------------
+-- | Builds an HTTP \"HEAD\" request with the given query parameters.
+--
+-- Example:
+--
+-- @
+-- ghci> :set -XOverloadedStrings
+-- ghci> import qualified "Data.Map" as M
+-- ghci> 'buildRequest' $ 'head' \"\/foo\/bar\" (M.fromList ("param0", ["baz", "quux"])])
+-- HEAD \/foo\/bar?param0=baz&param0=quux HTTP\/1.1
+-- host: localhost
+--
+-- sn="localhost" c=127.0.0.1:60000 s=127.0.0.1:8080 ctx=\/ clen=n\/a
+-- params: param0: ["baz","quux"]
+-- @
+-- @since 1.0.4.3 
+head :: MonadIO m =>
+        ByteString              -- ^ request path
+     -> Params                  -- ^ request's form parameters
+     -> RequestBuilder m ()
+head uri params = do
+  setRequestType . RequestWithRawBody HEAD $ ""
+  setQueryString params
+  setRequestPath uri
 
 ------------------------------------------------------------------------------
 -- | Builds an HTTP \"DELETE\" request with the given query parameters.

--- a/src/Snap/Test.hs
+++ b/src/Snap/Test.hs
@@ -19,6 +19,7 @@ module Snap.Test
 
     -- *** Convenience functions for generating common types of HTTP requests
   , get
+  , head
   , postUrlEncoded
   , postMultipart
   , put

--- a/test/Snap/Test/Tests.hs
+++ b/test/Snap/Test/Tests.hs
@@ -18,7 +18,7 @@ import           Data.Maybe                        (fromJust, isJust)
 import           Data.Text                         (Text)
 import           Data.Time.Clock                   (getCurrentTime)
 import           Prelude                           (Bool (True, False), IO, Int, Maybe (Just, Nothing), Monad (..), Ord (..), const, fail, fromIntegral, return, seq, show, ($), ($!), (*), (.))
-import           Snap.Core                         (Cookie (Cookie, cookieExpires), Method (DELETE, GET, Method, PATCH, POST, PUT), Request (rqContentLength, rqContextPath, rqIsSecure, rqMethod, rqParams, rqPathInfo, rqPostParams, rqQueryParams, rqQueryString, rqURI, rqVersion), Snap, expireCookie, extendTimeout, getCookie, getHeader, getParam, logError, readCookie, redirect, runSnap, terminateConnection, writeBS)
+import           Snap.Core                         (Cookie (Cookie, cookieExpires), Method (DELETE, GET, HEAD, Method, PATCH, POST, PUT), Request (rqContentLength, rqContextPath, rqIsSecure, rqMethod, rqParams, rqPathInfo, rqPostParams, rqQueryParams, rqQueryString, rqURI, rqVersion), Snap, expireCookie, extendTimeout, getCookie, getHeader, getParam, logError, readCookie, redirect, runSnap, terminateConnection, writeBS)
 import           Snap.Internal.Http.Types          (Request (..), Response (rspCookies))
 import qualified Snap.Internal.Http.Types          as T
 import           Snap.Internal.Test.RequestBuilder (FileData (FileData), MultipartParam (Files, FormData), RequestBuilder, RequestType (DeleteRequest, GetRequest, MultipartPostRequest, RequestWithRawBody, UrlEncodedPostRequest), addCookies, addHeader, buildRequest, delete, evalHandler, get, postMultipart, postRaw, postUrlEncoded, put, requestToString, responseToString, runHandler, setContentType, setHeader, setHttpVersion, setQueryStringRaw, setRequestPath, setRequestType, setSecure)
@@ -103,6 +103,9 @@ testSetRequestType = testCase "test/requestBuilder/setRequestType" $ do
 
     request7 <- buildRequest $ setRequestType $ RequestWithRawBody PATCH "bar"
     assertEqual "setRequestType/7/Method" PATCH (rqMethod request7)
+
+    request8 <- buildRequest $ setRequestType $ RequestWithRawBody HEAD ""
+    assertEqual "setRequestType/8/Method" HEAD (rqMethod request8)
 
   where
     rt4 = MultipartPostRequest [ ("foo", FormData ["foo"])

--- a/test/Snap/Util/CORS/Tests.hs
+++ b/test/Snap/Util/CORS/Tests.hs
@@ -60,7 +60,7 @@ testCORSOptions = testCase "CORS/options" $ do
        opts $ return ()
   checkAllowOrigin (Just origin) r
   checkAllowCredentials (Just "true") r
-  checkAllowHeaders (Just "X-STUFF, Content-Type") r
+  checkAllowHeaders (Just "Content-Type, X-STUFF") r
   checkAllowMethods (Just "GET") r
   ---------------------------------------------------------
   s <- runHandler (mkMethReq OPTIONS


### PR DESCRIPTION
This adds a `head` helper to `Snap.Test`, similar in spirit to `get` and such. I also add test coverage for this, as well as repairing a failing CORS test due to argument order.