### PR TITLE
Try fixing GHC 7.4 CI build

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -194,6 +194,11 @@ Library
     build-depends: network-uri >= 2.5 && < 2.6,
                    network     >= 2.3 && < 2.6
 
+  if impl(ghc >= 7.6)
+    build-depends: unix-compat >= 0.3 && < 0.6
+  else
+    build-depends: unix-compat >= 0.3 && < 0.5.3
+
 
 Test-suite testsuite
   hs-source-dirs: src test


### PR DESCRIPTION
unix-compat version 0.5.3 doesn't build on GHC 7.4