### PR TITLE
Build on GHC 9.2.4

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -1,5 +1,5 @@
 name:           snap-core
-version:        1.0.5.0
+version:        1.0.5.1
 synopsis:       Snap: A Haskell Web Framework (core interfaces and types)
 
 description:
@@ -36,7 +36,7 @@ bug-reports:    https://github.com/snapframework/snap-core/issues
 category:       Web, Snap, IO-Streams
 Tested-With:    GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
                 GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5,
-                GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.1
+                GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4
 
 extra-source-files:
   test/TestSuite.hs,
@@ -141,7 +141,7 @@ Library
     filepath                  >= 1.1     && < 2.0,
     lifted-base               >= 0.1     && < 0.3,
     io-streams                >= 1.3     && < 1.6,
-    hashable                  >= 1.2.0.6 && < 1.4,
+    hashable                  >= 1.2.0.6 && < 1.5,
     monad-control             >= 1.0     && < 1.1,
     mtl                       >= 2.0     && < 2.3,
     random                    >= 1       && < 2,

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,4 @@ resolver: lts-18.18
 
 #### Uncomment below to test GHC 9.2 on nightly
 #
-# resolver: nightly-2021-12-15
-# compiler: ghc-9.2.1
-#
-# extra-deps:
-#   - attoparsec-0.14.3
+# resolver: nightly-2022-10-06


### PR DESCRIPTION
Building with GHC 9.2.4 the tests in **snap-core** pass.

```
         Properties   Test Cases    Total        
 Passed  15           159           174          
 Failed  0            0             0            
 Total   15           159           174          
```

This closes https://github.com/snapframework/snap-core/issues/320, assuming the dependencies in **readable** are relaxed and it is released.

- https://github.com/mightybyte/readable/pull/5