### PR TITLE
Allow text-2.0

### DIFF
--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -147,7 +147,7 @@ Library
     random                    >= 1       && < 2,
     readable                  >= 0.1     && < 0.4,
     regex-posix               >= 0.95    && < 1,
-    text                      >= 0.11    && < 1.3,
+    text                      >= 0.11    && < 2.1,
     time                      >= 1.0     && < 1.14,
     transformers              >= 0.3     && < 0.6,
     transformers-base         >= 0.4     && < 0.5,


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.4.2
