### PR TITLE
Bump `text`, `deepseq` and CI for GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,16 @@ jobs:
           - "9.2"
           - "9.4"
           - "9.6"
+          - "9.8"
         include:
-          - { os: macOS-latest,   ghc: "9.6" }
-          - { os: windows-latest, ghc: "9.6" }
+          - { os: macOS-latest,   ghc: "9.8" }
+          - { os: windows-latest, ghc: "9.8" }
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up GHC ${{ matrix.ghc-version }}
-        uses: haskell/actions/setup@v2
+      - name: Set up GHC ${{ matrix.ghc }}
+        uses: haskell-actions/setup@v2
         id: setup
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -40,8 +40,9 @@ tested-with:
   GHC == 8.10.7
   GHC == 9.0.2
   GHC == 9.2.8
-  GHC == 9.4.5
-  GHC == 9.6.2
+  GHC == 9.4.7
+  GHC == 9.6.3
+  GHC == 9.8.1
 
 extra-source-files:
   test/TestSuite.hs,
@@ -157,7 +158,7 @@ Library
     random                    >= 1       && < 2,
     readable                  >= 0.1     && < 0.4,
     regex-posix               >= 0.95    && < 1,
-    text                      >= 0.11    && < 2.1,
+    text                      >= 0.11    && < 2.2,
     time                      >= 1.0     && < 1.14,
     transformers              >= 0.3     && < 0.7,
     transformers-base         >= 0.4     && < 0.5,
@@ -281,7 +282,7 @@ Test-suite testsuite
     vector,
     --------------------------------------------------------------------------
     QuickCheck                 >= 2.3.0.2  && <3,
-    deepseq                    >= 1.1      && < 1.5,
+    deepseq                    >= 1.1      && < 1.6,
     parallel                   >= 3        && <4,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.2.7    && <0.4,


### PR DESCRIPTION
CI running here: https://github.com/andreasabel/snap-core/pull/1

Published as revision 3: https://hackage.haskell.org/package/snap-core-1.0.5.1/revisions/