### PR TITLE
Allow zlib-0.7, time-1.14, drop GHC 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - { os: windows-latest, ghc: "9.8" }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up GHC ${{ matrix.ghc }}
         uses: haskell-actions/setup@v2
@@ -55,7 +55,7 @@ jobs:
           cabal build --dry-run
 
       - name: Restore cached dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: cache
         env:
           key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
@@ -68,7 +68,7 @@ jobs:
         run: cabal build all --only-dependencies
 
       - name: Save cached dependencies
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
@@ -95,10 +95,10 @@ jobs:
         include:
           # GHC version must match https://www.stackage.org/nightly
           - stack: "latest"
-            ghc: "9.6"
+            ghc: "9.8"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: haskell-actions/setup@v2
         name: Setup Haskell Stack
@@ -111,7 +111,7 @@ jobs:
           stack config set system-ghc true --global
           stack config set resolver nightly
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache
         with:
           path: |

--- a/snap-core.cabal
+++ b/snap-core.cabal
@@ -40,9 +40,9 @@ tested-with:
   GHC == 8.10.7
   GHC == 9.0.2
   GHC == 9.2.8
-  GHC == 9.4.7
-  GHC == 9.6.3
-  GHC == 9.8.1
+  GHC == 9.4.8
+  GHC == 9.6.4
+  GHC == 9.8.2
 
 extra-source-files:
   test/TestSuite.hs,
@@ -101,7 +101,7 @@ common universal
   default-language: Haskell2010
 
   build-depends:
-   , base >= 4 && < 5
+   , base >= 4.9 && < 5
 
 Library
   import: universal
@@ -116,7 +116,6 @@ Library
   else
     c-sources: cbits/timefuncs.c
     include-dirs: cbits
-    build-depends: old-locale >= 1 && <2
 
   exposed-modules:
     Snap.Core,
@@ -147,9 +146,9 @@ Library
     bytestring                >= 0.9     && < 0.13,
     bytestring-builder        >= 0.10.4  && < 0.11,
     case-insensitive          >= 1.1     && < 1.3,
-    containers                >= 0.3     && < 1.0,
+    containers                >= 0.3     && < 1,
     directory                 >= 1       && < 2,
-    filepath                  >= 1.1     && < 2.0,
+    filepath                  >= 1.1     && < 2,
     lifted-base               >= 0.1     && < 0.3,
     io-streams                >= 1.3     && < 1.6,
     hashable                  >= 1.2.0.6 && < 1.5,
@@ -159,7 +158,7 @@ Library
     readable                  >= 0.1     && < 0.4,
     regex-posix               >= 0.95    && < 1,
     text                      >= 0.11    && < 2.2,
-    time                      >= 1.0     && < 1.14,
+    time                      >= 1.0     && < 1.15,
     transformers              >= 0.3     && < 0.7,
     transformers-base         >= 0.4     && < 0.5,
     unix-compat               >= 0.3     && < 0.8,
@@ -184,18 +183,10 @@ Library
     ScopedTypeVariables,
     TypeSynonymInstances
 
-  if impl(ghc >= 6.12.0)
-    ghc-options: -Wall -fwarn-tabs -fno-warn-unused-do-bind
-  else
-    ghc-options: -Wall -fwarn-tabs
-
-  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
-
-  if impl(ghc < 8.8)
-    if impl(ghc >= 8.0)
-      ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
-    else
-      build-depends: fail == 4.9.*, semigroups >= 0.18 && < 0.20
+  ghc-options:
+    -Wall
+    -Wcompat
+    -fno-warn-unused-do-bind
 
   if flag(network-uri)
     -- Leaving network-uri-2.7.0.0 out for now because it is marked deprecated
@@ -204,10 +195,6 @@ Library
   else
     build-depends: network-uri >= 2.5 && < 2.6,
                    network     >= 2.3 && < 2.6
-
-  if !impl(ghc >= 7.6)
-    build-depends: unix-compat >= 0.3 && < 0.5.3
-
 
 Test-suite testsuite
   import:         universal
@@ -221,7 +208,6 @@ Test-suite testsuite
   else
     c-sources: cbits/timefuncs.c
     include-dirs: cbits
-    build-depends: old-locale >= 1 && <2
 
   other-modules:
     Snap.Core,
@@ -282,12 +268,12 @@ Test-suite testsuite
     vector,
     --------------------------------------------------------------------------
     QuickCheck                 >= 2.3.0.2  && <3,
-    deepseq                    >= 1.1      && < 1.6,
+    deepseq                    >= 1.1      && <1.6,
     parallel                   >= 3        && <4,
     test-framework             >= 0.8.0.3  && <0.9,
     test-framework-hunit       >= 0.2.7    && <0.4,
     test-framework-quickcheck2 >= 0.2.12.1 && <0.4,
-    zlib                       >= 0.5      && <0.7
+    zlib                       >= 0.5      && <0.8
 
   if flag(network-uri)
     build-depends: network-uri,
@@ -296,15 +282,12 @@ Test-suite testsuite
     build-depends: network-uri,
                    network
 
-  ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -threaded
-               -fno-warn-unused-do-bind
-
-  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
-  if impl(ghc < 8.8)
-    if impl(ghc >= 8.0)
-      ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
-    else
-      build-depends: fail == 4.9.*, semigroups >= 0.18 && < 0.20
+  ghc-options:
+    -threaded
+    -funbox-strict-fields
+    -Wall
+    -Wcompat
+    -fno-warn-unused-do-bind
 
   other-extensions:
     BangPatterns,
@@ -327,4 +310,4 @@ Test-suite testsuite
 
 source-repository head
   type:     git
-  location: git://github.com/snapframework/snap-core.git
+  location: https://github.com/snapframework/snap-core.git


### PR DESCRIPTION
- **Fix stack CI (nightly is now 9.8), bump action versions**
- **Allow zlib-0.7, time-1.14, drop GHC 7, remove unused package old-locale**

GHC 7 is not tested any longer, so we can as well require `base >= 4.9` and drop a number of redundant conditionals.

Bumping zlib helps with:
- https://github.com/commercialhaskell/stackage/issues/7309